### PR TITLE
Update subject line formatting and test flag

### DIFF
--- a/app/api/submitForm/EmailTemplate.jsx
+++ b/app/api/submitForm/EmailTemplate.jsx
@@ -14,7 +14,9 @@ export function generateEmailContent({
   const isEmergency = formType === "emergency" || painLevel >= 8;
 
   // Enhanced subject for iPhone VIP notifications
-  const urgencyPrefix = isEmergency ? "🔴 Urgent" : "🗓️ New";
+  const urgencyPrefix = isEmergency
+    ? "🔴 Emergency Patient Request"
+    : "🗓️ New Patient Request";
   const subject = `${urgencyPrefix}: ${name} (Pain ${painLevel}/10) - ${phone} at ${timestamp}`;
 
   const introText = `You have received a new ${

--- a/app/api/submitForm/EmailTemplate.jsx
+++ b/app/api/submitForm/EmailTemplate.jsx
@@ -14,10 +14,8 @@ export function generateEmailContent({
   const isEmergency = formType === "emergency" || painLevel >= 8;
 
   // Enhanced subject for iPhone VIP notifications
-  const urgencyPrefix = isEmergency
-    ? "🔴 Emergency Patient Request"
-    : "🗓️ New Patient Request";
-  const subject = `${urgencyPrefix}: ${name} (Pain ${painLevel}/10) - ${phone} at ${timestamp}`;
+  const urgencyPrefix = isEmergency ? "🔴 Urgent" : "🗓️ New";
+  const subject = `${urgencyPrefix}: ${name} (Pain ${painLevel}/10) - ${phone} @ ${timestamp}`;
 
   const introText = `You have received a new ${
     isEmergency ? "<strong>emergency</strong> " : ""


### PR DESCRIPTION
- Subject line now uses @ instead of "at"
- Uses 🔴 Urgent or 🗓️ New depending on severity
- Test emails marked clearly in subject + body